### PR TITLE
Move boot from asm to C code

### DIFF
--- a/kernel/Makefile
+++ b/kernel/Makefile
@@ -27,6 +27,7 @@ SOURCES_C := \
 	diskio.c \
 	ff.c \
 	ffsystem.c \
+	rpi.c	\
 
 SOURCES_ASM := \
 	boot.S \

--- a/kernel/Makefile
+++ b/kernel/Makefile
@@ -38,6 +38,8 @@ build: kernel.a
 
 include $(TOPDIR)/build.mk
 
+rpi.o: CFLAGS+=-mcmodel=large
+
 kernel.a: $(OBJECTS)
 
 extra-clean:

--- a/kernel/boot.S
+++ b/kernel/boot.S
@@ -150,19 +150,14 @@ mmu_enable:
 	CMP	x4, 0x8 	//0x8 = el2
 	BEQ	change_el
 	
-el3_only:	
-
-	MRS	X0, SCR_EL3
-	ORR	X0, X0, #(1<<10)	// RW EL2 Execution state is AArch64.
-	ORR	X0, X0, #(1<<0)		// NS EL1 is Non-secure world.
-	MSR	SCR_EL3, x0
-
-	MOV	X0, #0b01001		// DAIF=0000
-	MSR	SPSR_EL3, X0 		// M[4:0]=01001 EL2h must match SCR_EL3.RW
-
+_el3_only:	
+    MOV x27, LR
+    BL el3_only
+    MOV LR, x27
+	
 	ADR	X0, change_el     	// el2_entry points to the first instruction of
 	MSR	ELR_EL3, X0       	// EL2 code.
-
+   
 	ERET	//jump to el2_entry
 
 change_el:

--- a/kernel/boot.S
+++ b/kernel/boot.S
@@ -33,7 +33,7 @@ set_link_register:
 	// [x3] core number 
 	MRS	X3, MPIDR_EL1 		// Multiprocessor Affinity Register
 	ANDS	X3, X3, #3
-	BEQ	clear_bss
+	BEQ	_clear_bss
 	
 cpu_mailbox_wait:	
 	// [CPU#1-CPU#3] Wait for entry point to appear in local mailbox #3
@@ -67,7 +67,7 @@ cpu_mailbox_wait:
 	CMP	X3, #0
 	BNE	setup_translation_table
 
-clear_bss:
+_clear_bss:
 	// [CPU#0] Clear BSS section.
 
 	LDR	X4, =_start
@@ -80,11 +80,10 @@ clear_bss:
 	DSB	SY
 	ISB
 	
-	LDR	x4, =PHYSADDR(_bss_start)
-	LDR	x5, =PHYSADDR(_bss_end)
-1:	STP 	xzr, xzr, [x4], #16
-	CMP	x4, x5
-	BLO	1b
+    // TODO save LR in x27 at the begin
+    MOV     x27, LR                         //LR contains target function (e.g. kernel_entry)
+    BL  clear_bss
+    MOV     LR, x27
 
 	/* Set stack address core0 */
 	LDR	X29, =_el1_stack

--- a/kernel/boot.S
+++ b/kernel/boot.S
@@ -18,12 +18,9 @@ _start:
 
 	// You must ensure this bit is set to 1 before the caches and MMU are
 	// enabled, or any cache and TLB maintenance operations are performed.
-enable_cache:
-	MRS	X0, S3_1_C15_C2_1
-	ORR	X0, X0, #(0x1 << 6)	// The  SMP bit.
-	MSR	S3_1_C15_C2_1, X0 
-	DSB	SY
-	ISB
+    MOV     x27, LR                         //LR contains target function (e.g. kernel_entry)
+    BL  enable_cache
+    MOV     LR, x27
 
 	
 set_link_register:	

--- a/kernel/boot.S
+++ b/kernel/boot.S
@@ -87,10 +87,9 @@ _clear_bss:
 
 setup_translation_table:
 	/* Invalidate all TLB */
-	TLBI	ALLE1
-	TLBI	vmalle1is
-	DSB	ish
-	ISB
+    MOV x27, LR
+    BL invalidate_tlb
+    MOV LR, x27
 
 	ADR	X0, PHYSADDR(_level1_pagetable)	// ttb0_base must be a 4KB-aligned address.
 	MSR	TTBR1_EL1, X0
@@ -121,10 +120,10 @@ mmu_setup:
 
 	
 	/* Invalidate all TLB */
-	DSB	ishst
-	TLBI	vmalle1is
-	DSB	ish
-	ISB	
+    MOV x27, LR
+    BL invalidate_tlb
+    MOV LR, x27
+
 
 	LDR	x0, =( \
 	TCR_TxSZ(32) \

--- a/kernel/boot.S
+++ b/kernel/boot.S
@@ -91,9 +91,9 @@ setup_translation_table:
     BL invalidate_tlb
     MOV LR, x27
 
-	ADR	X0, PHYSADDR(_level1_pagetable)	// ttb0_base must be a 4KB-aligned address.
-	MSR	TTBR1_EL1, X0
-	MSR	TTBR0_EL1, X0
+    MOV x27, LR
+    BL setup_tlb
+    MOV LR, x27
 
     MOV x27, LR
     BL setup_tmp_stack

--- a/kernel/boot.S
+++ b/kernel/boot.S
@@ -153,15 +153,10 @@ _change_el:
     BL change_el
     MOV LR, x27
 		
-el2_entry:
-	/* Enable access to the physical timers at EL1 */
-	MRS	x2, cnthctl_el2
-	ORR	x2, x2, #(CNTHCTL_EL1PCTEN | CNTHCTL_EL1PCEN)
-	MSR	cnthctl_el2, x2
-	
-	// Determine the  EL1 Execution state
-	MOV	X1, #0b0101	 	// DAIF=0000
-	MSR	SPSR_EL2, X1      	// M[4:0]=00101 EL1h must match HCR_EL2.RW.
+_el2_entry:
+    MOV x27, LR
+    BL el2_entry
+    MOV LR, x27
 	
 	ADR	X1, el1_entry     	// el1_entry points to the first instruction of
 	MSR	ELR_EL2, X1       	// EL1 code.

--- a/kernel/boot.S
+++ b/kernel/boot.S
@@ -92,47 +92,10 @@ setup_translation_table:
     MOV LR, x27
 
 mmu_setup:
-	DSB	sy
-	ISB
-
-	LDR 	X0, =(	\
-	MAIR_ATTR(MAIR_DEVICE_nGnRnE, 	ATTR_DEVICE_MEM) \
-        | MAIR_ATTR(MAIR_NORMAL_NC, 	ATTR_NORMAL_MEM_NC) 	\
-	| MAIR_ATTR(MAIR_NORMAL_WB, 	ATTR_NORMAL_MEM_WB) 	\
-	| MAIR_ATTR(MAIR_NORMAL_WT, 	ATTR_NORMAL_MEM_WT)	\
-	)
-	MSR MAIR_EL1, X0
-
-	
-	/* Invalidate all TLB */
     MOV x27, LR
-    BL invalidate_tlb
+    BL setup_mmu
     MOV LR, x27
 
-
-	LDR	x0, =( \
-	TCR_TxSZ(32) \
-	| TCR_TGx_(4K) \
-	| TCR_IPS_32BIT \
-	| (1<<39)/*TCR_HA*/ \
-	| (1<<40)/*TCR_HD*/ \
-	)
-	MRS	x1, id_aa64mmfr0_el1
-	BFI	x0, x1, #32, #3
-	MSR	tcr_el1, x0
-
-	LDR	x1, =( \
-	SCTLR_M	\
-	| SCTLR_I \
-	| SCTLR_C \
-	)
-	ORR	x0, x0, x1
-
-mmu_enable:
-    MOV x27, LR
-    BL enable_mmu
-    MOV LR, x27
-	
 	MRS	x4, CurrentEl	
 	CMP	x4, 0x8 	//0x8 = el2
 	BEQ	_change_el

--- a/kernel/boot.S
+++ b/kernel/boot.S
@@ -2,157 +2,47 @@
 #include "aarch64/pte.h"
 #include "dev/bcm2836reg.h"
 
-#define CPU_STACK_SIZE 4096
-#define UPPERADDR 0xffffFFFF00000000
-#define PHYSADDR(x) ((x) - (UPPERADDR))
+#define STACK_START_SIZE 0x38
 
 .section ".init"
 
-.globl _start
+.global _start
 _start:
-	//start at el3 or el2
-	MRS 	X4, ID_MMFR2_EL1
-	MRS	x4, CurrentEl	
-	CMP	x4, 0x8 	//0x8 = el2
-	BEQ	set_link_register //if el2 then jump else:   
+    /* --- save atags register
+     * x27 is callee-saved */
+    MOV  x27, x0
+    /* --- get CPU number */
+    MRS  x3, MPIDR_EL1
+    AND  x3, x3, #3
+    
+    /* --- let's add 1 to the CPU number */
+    ADD  x3, x3, #0x1
+    /* we can use free space between 0x0 and 0x100 as temporary stack
+     * 0x100 is used for atags
+     * and SP must be aligned to 8
+     * so now we have 56 bytes for stack for each CPU
+     * 0x38 for CPU0
+     * 0x70 for CPU1
+     * 0xa8 for CPU2
+     * 0xe0 for CPU3 */
+    MOV  x4, STACK_START_SIZE
+    MUL  x4, x3, x4
+    
+    /* --- but we need additional bytes for CPU0
+     * let's move all the stacks by 24 bytes 
+     * 0x50 for CPU0
+     * 0x88 for CPU1
+     * 0xc0 for CPU2
+     * 0xf8 for CPU3 */
+    ADD  x4, x4, 0x18
+    MOV  SP, x4
 
-	// You must ensure this bit is set to 1 before the caches and MMU are
-	// enabled, or any cache and TLB maintenance operations are performed.
-    MOV     x27, LR                         //LR contains target function (e.g. kernel_entry)
-    BL  enable_cache
-    MOV     LR, x27
+    BL   arm64_init
 
-	
-set_link_register:	
-	// [lr] kernel entry point
-	LDR 	lr, =kernel_entry
+    BL   platform_stack
+    MOV  SP, x0
+    /* --- now we have stack */
 
-	// [x3] core number 
-	MRS	X3, MPIDR_EL1 		// Multiprocessor Affinity Register
-	ANDS	X3, X3, #3
-	BEQ	_clear_bss
-	
-cpu_mailbox_wait:	
-	// [CPU#1-CPU#3] Wait for entry point to appear in local mailbox #3
-	LSL	X3, X3, #4
-	LDR	X1, =_kernel
-
-	// jump address
-	LDR	X4, =BCM2836_ARM_LOCAL_BASE + BCM2836_LOCAL_MAILBOX3_CLRN(0)
-2:	WFE
-	LDR	W30, [X4, X3]	// lr == x30 there is no wlr |  read mailbox #3 for n-th CPU
-	CMP	LR, #0
-	BEQ	2b
-	
-	STR	W30, [X4, X3]	// clear the mailbox
-	ADD	LR, LR, X1
-
-	DSB	SY
-	ISB
-
-	// stack address
-	LDR	X4, =BCM2836_ARM_LOCAL_BASE + BCM2836_LOCAL_MAILBOX1_CLRN(0)
-3:	NOP
-	LDR	W29, [X4, X3]
-	CMP	W29, #0
-	BEQ	3b
-
-	STR	W29, [X4, X3]
-	ADD	X29, X29, X1
-
-	LSR	X3, X3, #4
-	CMP	X3, #0
-	BNE	setup_translation_table
-
-_clear_bss:
-	// [CPU#0] Clear BSS section.
-
-	LDR	X4, =_start
-	MOV	X5, #240
-	STR 	X4,[X5]
-	MOV	X5, #232
-	STR 	X4,[X5]
-	MOV	X5, #224
-	STR 	X4,[X5]
-	DSB	SY
-	ISB
-	
-    // TODO save LR in x27 at the begin
-    MOV     x27, LR                         //LR contains target function (e.g. kernel_entry)
-    BL  clear_bss
-    MOV     LR, x27
-
-	/* Set stack address core0 */
-	LDR	X29, =_el1_stack
-
-setup_translation_table:
-    MOV x27, LR
-    BL setup_tmp_stack
-    BL setup_tlb
-    MOV LR, x27
-
-mmu_setup:
-    MOV x27, LR
-    BL setup_mmu
-    MOV LR, x27
-
-	MRS	x4, CurrentEl	
-	CMP	x4, 0x8 	//0x8 = el2
-	BEQ	_change_el
-	
-_el3_only:	
-    MOV x27, LR
-    BL el3_only
-    MOV LR, x27
-	
-	ADR	X0, _change_el     	// el2_entry points to the first instruction of
-	MSR	ELR_EL3, X0       	// EL2 code.
-   
-	ERET	//jump to el2_entry
-
-_change_el:
-	// Initialize SCTLR_EL2 and HCR_EL2 to save values before entering EL2
-    MOV x27, LR
-    BL change_el
-    MOV LR, x27
-		
-_el2_entry:
-    MOV x27, LR
-    BL el2_entry
-    MOV LR, x27
-	
-	ADR	X1, el1_entry     	// el1_entry points to the first instruction of
-	MSR	ELR_EL2, X1       	// EL1 code.
-	ERET	
-	
-el1_entry:
-	/* Load the exception vectors */
-	LDR	x2, =_exc_vector
-	MSR	vbar_el1, x2
-
-	/* Set stack address */
-	MOV	SP, X29
-	MSR	DAIFClr, #3
-
-// Enter kernel_entry with empty stack.
-enter_kernel:
-
-	MOV	x4, lr
-	LDR	lr, =kernel_exit  
-  
-turn_off:
-// turn off user space adress translation
-	LDR	x3, =turn_off_user_space
-	LDR	x1, =_kernel
-
-	ADD	x1, x1, x3
-	BR	x1
-
-turn_off_user_space:
-	MSR	TTBR0_EL1, XZR
-
-	DSB	SY
-	ISB
-	BR	x4
-
-//vim: ft=armv5 ts=8 sw=8 noet	
+    /* --- restore atags register and go out of assembler's hell */
+    MOV  x0, x27
+    BL   platform_init 

--- a/kernel/boot.S
+++ b/kernel/boot.S
@@ -87,17 +87,9 @@ _clear_bss:
 
 setup_translation_table:
     MOV x27, LR
+    BL setup_tmp_stack
     BL setup_tlb
     MOV LR, x27
-
-    MOV x27, LR
-    BL setup_tmp_stack
-    MOV LR, x27
-
-	MOV	x27, LR				//LR contains target function (e.g. kernel_entry)
-	BL	page_table_fill_inner_nodes
-	BL	page_table_fill_leaves
-	MOV	LR, x27
 
 mmu_setup:
 	DSB	sy

--- a/kernel/boot.S
+++ b/kernel/boot.S
@@ -144,9 +144,9 @@ mmu_setup:
 	ORR	x0, x0, x1
 
 mmu_enable:
-	MSR	sctlr_el1, x0	/* enabling MMU! */
-	DSB	sy
-	ISB	
+    MOV x27, LR
+    BL enable_mmu
+    MOV LR, x27
 	
 	MRS	x4, CurrentEl	
 	CMP	x4, 0x8 	//0x8 = el2

--- a/kernel/boot.S
+++ b/kernel/boot.S
@@ -135,25 +135,23 @@ mmu_enable:
 	
 	MRS	x4, CurrentEl	
 	CMP	x4, 0x8 	//0x8 = el2
-	BEQ	change_el
+	BEQ	_change_el
 	
 _el3_only:	
     MOV x27, LR
     BL el3_only
     MOV LR, x27
 	
-	ADR	X0, change_el     	// el2_entry points to the first instruction of
+	ADR	X0, _change_el     	// el2_entry points to the first instruction of
 	MSR	ELR_EL3, X0       	// EL2 code.
    
 	ERET	//jump to el2_entry
 
-change_el:
+_change_el:
 	// Initialize SCTLR_EL2 and HCR_EL2 to save values before entering EL2
-	MSR	HCR_EL2, XZR   
-	MRS	X0, HCR_EL2
-	ORR	X0, X0, #(1<<31)	// RW=1  EL1  Execution state is AArch64.
-	//ORR	X0, X0, #(1 << 1)   	// SWIO hardwired on Pi3
-	MSR	HCR_EL2, X0
+    MOV x27, LR
+    BL change_el
+    MOV LR, x27
 		
 el2_entry:
 	/* Enable access to the physical timers at EL1 */

--- a/kernel/boot.S
+++ b/kernel/boot.S
@@ -95,11 +95,9 @@ setup_translation_table:
 	MSR	TTBR1_EL1, X0
 	MSR	TTBR0_EL1, X0
 
-	//tmp stack setup
-	MOV 	X1, X29
-	LDR	X2, =_kernel
-	SUBS	X1, X1, X2
-	MOV	SP, X1
+    MOV x27, LR
+    BL setup_tmp_stack
+    MOV LR, x27
 
 	MOV	x27, LR				//LR contains target function (e.g. kernel_entry)
 	BL	page_table_fill_inner_nodes

--- a/kernel/boot.S
+++ b/kernel/boot.S
@@ -86,11 +86,6 @@ _clear_bss:
 	LDR	X29, =_el1_stack
 
 setup_translation_table:
-	/* Invalidate all TLB */
-    MOV x27, LR
-    BL invalidate_tlb
-    MOV LR, x27
-
     MOV x27, LR
     BL setup_tlb
     MOV LR, x27

--- a/kernel/rpi.c
+++ b/kernel/rpi.c
@@ -13,3 +13,11 @@ void __attribute__((section(".init"))) clear_bss() {
   }
 }
 
+
+void __attribute__((section(".init"))) enable_cache() {
+  __asm__ volatile("MRS X0, S3_1_C15_C2_1\n"
+                   "ORR X0, X0, #(0x1 << 6)\n" // The SMP bit
+                   "MSR S3_1_C15_c2_1, X0\n"
+                   "DSB SY\n"
+                   "ISB\n");
+}

--- a/kernel/rpi.c
+++ b/kernel/rpi.c
@@ -28,3 +28,9 @@ void __attribute__((section(".init"))) invalidate_tlb() {
                    "DSB ish\n"
                    "ISB\n");
 }
+
+void __attribute__((section(".init"))) enable_mmu() {
+  __asm__ volatile("MSR sctlr_el1, x0\n"
+                   "DSB sy\n"
+                   "ISB\n");
+}

--- a/kernel/rpi.c
+++ b/kernel/rpi.c
@@ -23,14 +23,9 @@ void __init__ clear_bss(void) {
 }
 
 void __init__ enable_cache(void) {
-  uint64_t x;
-  __asm__ volatile("MRS %0, S3_1_C15_C2_1\n"
-                   : "=r" (x));
-  x |= (0x1 << 6); // The SMP bit
-  __asm__ volatile("MSR S3_1_C15_c2_1, %0\n"
-                   "DSB SY\n"
-                   "ISB\n"
-                   : : "r" (x));
+  WRITE_SPECIALREG(S3_1_C15_c2_1, READ_SPECIALREG(S3_1_C15_C2_1) | (0x1 << 6));
+  __asm__ volatile("DSB SY\n"
+                   "ISB\n");
 }
 
 void __init__ __inline__ invalidate_tlb(void) {
@@ -41,10 +36,9 @@ void __init__ __inline__ invalidate_tlb(void) {
 }
 
 void __init__ enable_mmu(uint64_t x) {
-  __asm__ volatile("MSR sctlr_el1, x0\n"
-                   "DSB sy\n"
-                   "ISB\n"
-                   : : "r" (x));
+  WRITE_SPECIALREG(sctlr_el1, x);
+  __asm__ volatile("DSB sy\n"
+                   "ISB\n");
 }
 
 void __init__ __inline__ setup_tmp_stack(void) {
@@ -55,26 +49,14 @@ void __init__ __inline__ setup_tmp_stack(void) {
 }
 
 void __init__ el3_only(void) {
-  uint64_t x;
-  __asm__ volatile("MRS %0, SCR_EL3\n"
-                   : "=r" (x));
-
-  x |= (0x1 << 10); // RW EL2 Execution state is AArch64.
-  x |= (0x1 << 0);  // NS EL1 is Non-secure world.
-
-  __asm__ volatile("MSR SCR_EL3, %0\n"  // DAIF=0000
-                   "MSR SPSR_EL3, %1\n" // M[4:0]=01001 EL2h must match SCR_EL3.RW
-                   : : "r" (x), "r" (0b01001));
+  WRITE_SPECIALREG(SCR_EL3, READ_SPECIALREG(SCR_EL3) | (0x1 << 10) | (0x1 << 0));
+  WRITE_SPECIALREG(SPSR_EL3, 0b01001);
 }
 
 void __init__ setup_tlb(void) {
   invalidate_tlb();
-
-  uint64_t x = PHYSADDR((uint64_t)&_level1_pagetable);
-  __asm__ volatile("MSR TTBR1_EL1, %0\n"
-                   "MSR TTBR0_EL1, %0\n"
-                   : : "r" (x));
-
+  WRITE_SPECIALREG(TTBR1_EL1, PHYSADDR((uint64_t)&_level1_pagetable));
+  WRITE_SPECIALREG(TTBR0_EL1, PHYSADDR((uint64_t)&_level1_pagetable));
   page_table_fill_inner_nodes();
   page_table_fill_leaves();
 }
@@ -82,25 +64,12 @@ void __init__ setup_tlb(void) {
 
 void __init__ change_el(void) {
   __asm__ volatile("MSR HCR_EL2, XZR\n");
-  uint64_t x;
-  __asm__ volatile("MRS %0, HCR_EL2\n"
-                   : "=r" (x));
-
-  x |= (1<<31); // RW=1 EL1 Execution state is AArch64
-  __asm__ volatile("MSR HCR_EL2, %0\n"
-                   : : "r" (x));
+  WRITE_SPECIALREG(HCR_EL2, READ_SPECIALREG(HCR_EL2) | (1<<31));
 }
 
 void __init__ el2_entry(void) {
-  uint64_t x;
-  /* Enable access to the physical timers at EL1 */
-  __asm__ volatile("MRS %0, cnthctl_el2\n"
-                   : "=r" (x));
-  x |= CNTHCTL_EL1PCTEN | CNTHCTL_EL1PCEN;
-  /* Determine the EL1 execution state */
-  __asm__ volatile("MSR cnthctl_el2, %0\n"
-                   "MSR SPSR_EL2, %1\n"
-                   : : "r" (x), "r" (0b0101));
+  WRITE_SPECIALREG(cnthctl_el2, READ_SPECIALREG(cnthctl_el2) | CNTHCTL_EL1PCTEN | CNTHCTL_EL1PCEN);
+  WRITE_SPECIALREG(SPSR_EL2, 0b0101);
 }
 
 void __init__ setup_mmu(void) {
@@ -109,20 +78,18 @@ void __init__ setup_mmu(void) {
       | MAIR_ATTR(MAIR_NORMAL_WB, ATTR_NORMAL_MEM_WB)
       | MAIR_ATTR(MAIR_NORMAL_WT, ATTR_NORMAL_MEM_WT);
   __asm__ volatile("DSB sy\n"
-                   "ISB\n"
-                   "MSR MAIR_EL1, %0\n"
-                   : : "r" (x));
+                   "ISB\n");
+  
+  WRITE_SPECIALREG(MAIR_EL1, x);
+
   invalidate_tlb();
 
   x = TCR_TxSZ(32ULL) | TCR_TGx_(4K) | (1ULL<<39ULL) | (1ULL<<40ULL);
-  uint64_t v;
-  __asm__ volatile("MRS %0, id_aa64mmfr0_el1\n"
-                   : "=r" (v));
+  uint64_t v = READ_SPECIALREG(id_aa64mmfr0_el1);
   __asm__ volatile("BFI %0, %1, #32, #3\n"
                    : "+r" (x)
                    : "r" (v));
-  __asm__ volatile("MSR tcr_el1, %0\n"
-                   : : "r" (x));
+  WRITE_SPECIALREG(tcr_el1, x);
   v = SCTLR_M | SCTLR_I | SCTLR_C;
   x |= v;
   enable_mmu(x);

--- a/kernel/rpi.c
+++ b/kernel/rpi.c
@@ -21,3 +21,10 @@ void __attribute__((section(".init"))) enable_cache() {
                    "DSB SY\n"
                    "ISB\n");
 }
+
+void __attribute__((section(".init"))) invalidate_tlb() {
+  __asm__ volatile("TLBI ALLE1\n"
+                   "TLBI vmalle1is\n"
+                   "DSB ish\n"
+                   "ISB\n");
+}

--- a/kernel/rpi.c
+++ b/kernel/rpi.c
@@ -1,5 +1,6 @@
 #include "types.h"
 #include "aarch64/aarch64reg.h"
+#include "aarch64/cpureg.h"
 #include "aarch64/pte.h"
 #include "dev/bcm2836reg.h"
 
@@ -8,89 +9,209 @@ extern uint64_t _bss_end[];
 extern uint64_t _level1_pagetable[];
 extern void page_table_fill_inner_nodes(void);
 extern void page_table_fill_leaves(void);
+extern void _exc_vector(void);
+extern uint8_t _el1_stack[];
+extern uint8_t _kernel[];
 
-#define UPPERADDR 0xffffFFFF00000000UL
+#define UPPERADDR 0xffffffff00000000UL
 #define PHYSADDR(x) ((x) - (UPPERADDR))
 
 #define __init__ __attribute__((section(".init")))
 #define __inline__ __attribute__((always_inline))
+#define __noreturn__ __attribute__((__noreturn__))
 
-void __init__ clear_bss(void) {
+__init__ static long get_cpu(void) {
+  /* --- we have CPU 0 - 3 so we only need 2 bits of MPIDR_EL1 */
+  return READ_SPECIALREG(MPIDR_EL1) & 0x3UL;
+}
+
+__init__ static void clear_bss(void) {
   for (uint64_t *i = (uint64_t *)PHYSADDR((uint64_t)&_bss_start);
-      i < (uint64_t *)PHYSADDR((uint64_t)&_bss_end); ++i) {
+       i < (uint64_t *)PHYSADDR((uint64_t)&_bss_end); ++i) {
     *i = 0;
   }
 }
 
-void __init__ enable_cache(void) {
-  WRITE_SPECIALREG(S3_1_C15_c2_1, READ_SPECIALREG(S3_1_C15_C2_1) | (0x1 << 6));
-  __asm__ volatile("DSB SY\n"
-                   "ISB\n");
+#if 0
+__init__ static intptr_t cpu_wait(void) {
+  for (;;) {
+    /* --- DO NOTHING */
+  }
+  return 0xdeadc0de;
 }
+#endif
 
-void __init__ __inline__ invalidate_tlb(void) {
+__init__ void invalidate_tlb(void) {
   __asm__ volatile("TLBI ALLE1\n"
                    "TLBI vmalle1is\n"
                    "DSB ish\n"
                    "ISB\n");
 }
 
-void __init__ enable_mmu(uint64_t x) {
+#if 0
+__init__ static void setup_tlb(void) {
+  invalidate_tlb();
+  WRITE_SPECIALREG(TTBR1_EL1, PHYSADDR((uint64_t)&_level1_pagetable));
+  WRITE_SPECIALREG(TTBR0_EL1, PHYSADDR((uint64_t)&_level1_pagetable));
+}
+#endif
+
+__init__ __inline__ static void enable_mmu(void) {
+  uint64_t x = MAIR_ATTR(MAIR_DEVICE_nGnRnE, ATTR_DEVICE_MEM)
+    | MAIR_ATTR(MAIR_NORMAL_NC, ATTR_NORMAL_MEM_NC)
+    | MAIR_ATTR(MAIR_NORMAL_WB, ATTR_NORMAL_MEM_WB)
+    | MAIR_ATTR(MAIR_NORMAL_WT, ATTR_NORMAL_MEM_WT);
+  __asm__ volatile("DSB sy\n"
+                   "ISB\n");
+
+  WRITE_SPECIALREG(MAIR_EL1, x);
+
+  invalidate_tlb();
+
+  /* --- enable magic bits
+   * 40 -- Hardware management of dirty state in stage 1 translations from EL0 and EL1.
+   * 39 -- Hardware Access flag update in stage 1 translations from EL0 and EL1.
+   * 32 -- Set Physical Address size to 4GB.
+   * 21 -- The size offset of the memory region addressed by TTBR1_EL1.
+   *  5 -- The size offset of the memory region addressed by TTBR1_EL0.
+   * 4K -- Granule size for the TTBR0_EL.
+   */
+  x = TCR_TxSZ(32ULL) | TCR_TGx_(4K) | (0ULL << 32ULL) | (1ULL << 39ULL) | (1ULL << 40ULL);
+  uint64_t v = READ_SPECIALREG(id_aa64mmfr0_el1);
+
+  /* --- Support for 16KB memory granule size for stage 2. (id_aa64mmfr0_el1)
+   * Intermediate Physical Address Size. (tcr_el1)
+   * */
+  __asm__ volatile("BFI %0, %1, #32, #3\n"
+                   : "+r" (x)
+                   : "r" (v));
+  WRITE_SPECIALREG(tcr_el1, x);
+
+  /* --- more magic bits
+   * M -- MMU enable for EL1 and EL0 stage 1 address translation. 
+   * I -- SP must be aligned to 16.
+   * C -- Cacheability control, for data accesses.
+   */
+  v = SCTLR_M | SCTLR_I | SCTLR_C;
+  x |= v;
+
   WRITE_SPECIALREG(sctlr_el1, x);
   __asm__ volatile("DSB sy\n"
                    "ISB\n");
 }
 
-void __init__ __inline__ setup_tmp_stack(void) {
-  __asm__ volatile("MOV X1, X29\n"
-                   "LDR X2, =_kernel\n"
-                   "SUBS X1, X1, X2\n"
-                   "MOV SP, X1\n");
+__init__ static void enable_cache(void) {
+  if (READ_SPECIALREG(CurrentEl) != 0x8) {
+    /* --- we are not in el2 */
+    /* 1 << 6 -- SMP bit */
+    WRITE_SPECIALREG(S3_1_C15_c2_1, READ_SPECIALREG(S3_1_C15_C2_1) | (0x1 << 6));
+    __asm__ volatile("DSB SY\n"
+                     "ISB\n");
+  }
 }
 
-void __init__ el3_only(void) {
-  WRITE_SPECIALREG(SCR_EL3, READ_SPECIALREG(SCR_EL3) | (0x1 << 10) | (0x1 << 0));
-  WRITE_SPECIALREG(SPSR_EL3, 0b01001);
-}
-
-void __init__ setup_tlb(void) {
-  invalidate_tlb();
-  WRITE_SPECIALREG(TTBR1_EL1, PHYSADDR((uint64_t)&_level1_pagetable));
-  WRITE_SPECIALREG(TTBR0_EL1, PHYSADDR((uint64_t)&_level1_pagetable));
-  page_table_fill_inner_nodes();
-  page_table_fill_leaves();
-}
-
-
-void __init__ change_el(void) {
-  __asm__ volatile("MSR HCR_EL2, XZR\n");
-  WRITE_SPECIALREG(HCR_EL2, READ_SPECIALREG(HCR_EL2) | (1<<31));
-}
-
-void __init__ el2_entry(void) {
-  WRITE_SPECIALREG(cnthctl_el2, READ_SPECIALREG(cnthctl_el2) | CNTHCTL_EL1PCTEN | CNTHCTL_EL1PCEN);
-  WRITE_SPECIALREG(SPSR_EL2, 0b0101);
-}
-
-void __init__ setup_mmu(void) {
-  uint64_t x = MAIR_ATTR(MAIR_DEVICE_nGnRnE, ATTR_DEVICE_MEM)
-      | MAIR_ATTR(MAIR_NORMAL_NC, ATTR_NORMAL_MEM_NC)
-      | MAIR_ATTR(MAIR_NORMAL_WB, ATTR_NORMAL_MEM_WB)
-      | MAIR_ATTR(MAIR_NORMAL_WT, ATTR_NORMAL_MEM_WT);
-  __asm__ volatile("DSB sy\n"
-                   "ISB\n");
+intptr_t platform_stack(void) {
+  // long cpu = get_cpu();
+  intptr_t stack = ((intptr_t)&_el1_stack) - ((intptr_t)&_kernel);;
   
-  WRITE_SPECIALREG(MAIR_EL1, x);
+  /* --- TODO(pj):
+   * - save boot params
+   * - bootstrap thread0
+   */
+ 
+  /* --- time to return stack */
+  return stack;
+}
 
+__noreturn__ void platform_init(void *atags) {
+  (void)atags;
+  for (;;) {
+    /* --- DO NOTHING */
+  }
+}
+
+__init__ long arm64_init(void) {
+  uint64_t x;
+  long cpu = get_cpu();
+  enable_cache();
   invalidate_tlb();
 
-  x = TCR_TxSZ(32ULL) | TCR_TGx_(4K) | (1ULL<<39ULL) | (1ULL<<40ULL);
-  uint64_t v = READ_SPECIALREG(id_aa64mmfr0_el1);
-  __asm__ volatile("BFI %0, %1, #32, #3\n"
-                   : "+r" (x)
-                   : "r" (v));
-  WRITE_SPECIALREG(tcr_el1, x);
-  v = SCTLR_M | SCTLR_I | SCTLR_C;
-  x |= v;
-  enable_mmu(x);
+
+#if 1
+  if (cpu == 0) {
+    /* --- now we are CPU0 */
+    clear_bss();
+    page_table_fill_inner_nodes();
+    page_table_fill_leaves();
+    WRITE_SPECIALREG(TTBR1_EL1, PHYSADDR((uint64_t)&_level1_pagetable));
+    WRITE_SPECIALREG(TTBR0_EL1, PHYSADDR((uint64_t)&_level1_pagetable));
+    enable_mmu();
+  }
+#endif
+
+  /* --- el3_only */
+  /* --- 0x8 = EL2 */
+  if (READ_SPECIALREG(CurrentEl) != 0x8) {
+    /* --- we are not in el2 */
+    x = READ_SPECIALREG(SCR_EL3);
+    /* --- Execution state control for lower Exception levels. 
+     * The next lower level is AArch64 */
+    x |= (1 << 10);
+    /* --- Non-secure bit. 
+     * Indicates that Exception levels lower than EL3 are in Non-secure state, 
+     * and so memory accesses from those Exception levels cannot access Secure 
+     * memory.
+     */
+    x |= (1 << 0);
+    WRITE_SPECIALREG(SP_EL2, reg_sp_read());
+    WRITE_SPECIALREG(SCR_EL3, x);
+    WRITE_SPECIALREG(SPSR_EL3, 0b01001);
+    WRITE_SPECIALREG(ELR_EL3, &&el2_entry);
+    __asm__ volatile ("ERET\n");
+  }
+
+el2_entry:
+  WRITE_SPECIALREG(HCR_EL2, 0);
+  /* The Execution state for EL1 is AArch64. The Execution state for EL0 is determined
+   * by the current value of PSTATE.nRW when executing at EL0.
+   */
+  x = READ_SPECIALREG(HCR_EL2) | (1 << 31);
+  WRITE_SPECIALREG(HCR_EL2, x);
+
+  x = READ_SPECIALREG(CNTHCTL_EL2);
+  x |= CNTHCTL_EL1PCTEN | CNTHCTL_EL1PCEN;
+  /* --- enable timer for EL1 */
+  WRITE_SPECIALREG(SP_EL1, reg_sp_read());
+  WRITE_SPECIALREG(CNTHCTL_EL2, x);
+  WRITE_SPECIALREG(SPSR_EL2, 0b0101);
+  WRITE_SPECIALREG(ELR_EL2, &&el1_entry);
+  __asm__ volatile ("ERET\n");
+
+el1_entry:
+  WRITE_SPECIALREG(VBAR_EL1, _exc_vector);
+  /* --- I don't have any idea why this instruction doesn't work */
+#if 0
+  WRITE_SPECIALREG(DAIFClr, 3);
+#else
+  __asm__ volatile ("MSR DAIFClr, #3\n");
+#endif
+
+  if (cpu == 0) {
+    /* --- now we are CPU0 */
+#if 0
+    clear_bss();
+    page_table_fill_inner_nodes();
+    page_table_fill_leaves();
+    WRITE_SPECIALREG(TTBR1_EL1, PHYSADDR((uint64_t)&_level1_pagetable));
+    WRITE_SPECIALREG(TTBR0_EL1, PHYSADDR((uint64_t)&_level1_pagetable));
+    enable_mmu();
+    // WRITE_SPECIALREG(VBAR_EL1, _exc_vector);
+#endif
+  } else {
+    for (;;) {
+      /* --- DO NOTHING */
+    }
+  }
+
+  return cpu;
 }

--- a/kernel/rpi.c
+++ b/kernel/rpi.c
@@ -1,4 +1,8 @@
 #include "types.h"
+#include "aarch64/aarch64reg.h"
+#include "aarch64/pte.h"
+#include "dev/bcm2836reg.h"
+
 
 extern uint64_t _bss_start[];
 extern uint64_t _bss_end[];
@@ -40,4 +44,13 @@ void __attribute__((section(".init"))) setup_tmp_stack() {
                    "LDR X2, =_kernel\n"
                    "SUBS X1, X1, X2\n"
                    "MOV SP, X1\n");
+}
+
+void __attribute__((section(".init"))) el3_only() {
+  __asm__ volatile("MRS X0, SCR_EL3\n"
+                   "ORR X0, X0, #(1<<10)\n" // RW EL2 Execution state is AArch64.
+                   "ORR X0, X0, #(1<<0)\n" // NS EL1 is Non-secure world.
+                   "MSR SCR_EL3, X0\n" 
+                   "MOV X0, #0b01001\n" // DAIF=0000
+                   "MSR SPSR_EL3, X0\n"); // M[4:0]=01001 EL2h must match SCR_EL3.RW
 }

--- a/kernel/rpi.c
+++ b/kernel/rpi.c
@@ -34,3 +34,10 @@ void __attribute__((section(".init"))) enable_mmu() {
                    "DSB sy\n"
                    "ISB\n");
 }
+
+void __attribute__((section(".init"))) setup_tmp_stack() {
+  __asm__ volatile("MOV X1, X29\n"
+                   "LDR X2, =_kernel\n"
+                   "SUBS X1, X1, X2\n"
+                   "MOV SP, X1\n");
+}

--- a/kernel/rpi.c
+++ b/kernel/rpi.c
@@ -22,7 +22,6 @@ void __init__ clear_bss() {
   }
 }
 
-
 void __init__ enable_cache() {
   uint64_t x;
   __asm__ volatile("MRS %0, S3_1_C15_C2_1\n"
@@ -50,7 +49,7 @@ void __init__ enable_mmu() {
                    "ISB\n");
 }
 
-void __init__ setup_tmp_stack() {
+void __init__ __inline__ setup_tmp_stack() {
   __asm__ volatile("MOV X1, X29\n"
                    "LDR X2, =_kernel\n"
                    "SUBS X1, X1, X2\n"
@@ -83,5 +82,8 @@ void __init__ setup_tlb() {
                    : \
                    : "r" (x) \
                   );
+
+  page_table_fill_inner_nodes();
+  page_table_fill_leaves();
 }
 

--- a/kernel/rpi.c
+++ b/kernel/rpi.c
@@ -1,0 +1,15 @@
+#include "types.h"
+
+extern uint64_t _bss_start[];
+extern uint64_t _bss_end[];
+
+#define UPPERADDR 0xffffFFFF00000000UL
+#define PHYSADDR(x) ((x) - (UPPERADDR))
+
+void __attribute__((section(".init"))) clear_bss() {
+  for (uint64_t *i = (uint64_t *)PHYSADDR((uint64_t)&_bss_start);
+      i < (uint64_t *)PHYSADDR((uint64_t)&_bss_end); ++i) {
+    *i = 0;
+  }
+}
+

--- a/kernel/rpi.c
+++ b/kernel/rpi.c
@@ -15,19 +15,17 @@ extern void page_table_fill_leaves(void);
 #define __init__ __attribute__((section(".init")))
 #define __inline__ __attribute__((always_inline))
 
-void __init__ clear_bss() {
+void __init__ clear_bss(void) {
   for (uint64_t *i = (uint64_t *)PHYSADDR((uint64_t)&_bss_start);
       i < (uint64_t *)PHYSADDR((uint64_t)&_bss_end); ++i) {
     *i = 0;
   }
 }
 
-void __init__ enable_cache() {
+void __init__ enable_cache(void) {
   uint64_t x;
   __asm__ volatile("MRS %0, S3_1_C15_C2_1\n"
-                   : "=r" (x)
-                   :
-      );
+                   : "=r" (x));
   x |= (0x1 << 6); // The SMP bit
   __asm__ volatile("MSR S3_1_C15_c2_1, %0\n"
                    "DSB SY\n"
@@ -36,7 +34,7 @@ void __init__ enable_cache() {
                    : "r" (x));
 }
 
-void __init__ __inline__ invalidate_tlb() {
+void __init__ __inline__ invalidate_tlb(void) {
   __asm__ volatile("TLBI ALLE1\n"
                    "TLBI vmalle1is\n"
                    "DSB ish\n"
@@ -49,19 +47,18 @@ void __init__ enable_mmu() {
                    "ISB\n");
 }
 
-void __init__ __inline__ setup_tmp_stack() {
+void __init__ __inline__ setup_tmp_stack(void) {
   __asm__ volatile("MOV X1, X29\n"
                    "LDR X2, =_kernel\n"
                    "SUBS X1, X1, X2\n"
                    "MOV SP, X1\n");
 }
 
-void __init__ el3_only() {
+void __init__ el3_only(void) {
   uint64_t x;
   __asm__ volatile("MRS %0, SCR_EL3\n"
                    : "=r" (x)
-                   :
-      );
+                   :);
 
   x |= (0x1 << 10); // RW EL2 Execution state is AArch64.
   x |= (0x1 << 0);  // NS EL1 is Non-secure world.
@@ -69,21 +66,32 @@ void __init__ el3_only() {
   __asm__ volatile("MSR SCR_EL3, %0\n"  // DAIF=0000
                    "MSR SPSR_EL3, %1\n" // M[4:0]=01001 EL2h must match SCR_EL3.RW
                    : 
-                   : "r" (x), "r" (0b01001))
-    ;
+                   : "r" (x), "r" (0b01001));
 }
 
-void __init__ setup_tlb() {
+void __init__ setup_tlb(void) {
   invalidate_tlb();
 
   uint64_t x = PHYSADDR((uint64_t)&_level1_pagetable);
   __asm__ volatile("MSR TTBR1_EL1, %0\n"
                    "MSR TTBR0_EL1, %0\n"
-                   : \
-                   : "r" (x) \
-                  );
+                   :
+                   : "r" (x));
 
   page_table_fill_inner_nodes();
   page_table_fill_leaves();
+}
+
+
+void __init__ change_el(void) {
+  __asm__ volatile("MSR HCR_EL2, XZR\n");
+  uint64_t x;
+  __asm__ volatile("MRS %0, HCR_EL2\n"
+                   : "=r" (x));
+
+  x |= (1<<31); // RW=1 EL1 Execution state is AArch64
+  __asm__ volatile("MSR HCR_EL2, %0\n"
+                   : 
+                   : "r" (x));
 }
 

--- a/kernel/rpi.c
+++ b/kernel/rpi.c
@@ -95,3 +95,15 @@ void __init__ change_el(void) {
                    : "r" (x));
 }
 
+void __init__ el2_entry(void) {
+  uint64_t x;
+  /* Enable access to the physical timers at EL1 */
+  __asm__ volatile("MRS %0, cnthctl_el2\n"
+                   : "=r" (x));
+  x |= CNTHCTL_EL1PCTEN | CNTHCTL_EL1PCEN;
+  /* Determine the EL1 execution state */
+  __asm__ volatile("MSR cnthctl_el2, %0\n"
+                   "MSR SPSR_EL2, %1\n"
+                   :
+                   : "r" (x), "r" (0b0101));
+}

--- a/kernel/smp.c
+++ b/kernel/smp.c
@@ -18,7 +18,6 @@ static inline uint64_t stack_addr_read() {
 }
 
 void smp_intro() {
-
   unsigned cpu = arm_cpu_id();
   pcpu_init();
   cons_bootstrap(cpu);
@@ -54,10 +53,9 @@ smp_demo(none, false);
 void smp_bootstrap() {
 #define L2I (uint32_t)(uint64_t)
 
-  int cpu = 0;
-  mbox_send(cpu + 1, 3, L2I smp_demo_clock);
-  mbox_send(cpu + 2, 3, L2I smp_demo_sd);
-  mbox_send(cpu + 3, 3, L2I smp_demo_pmap);
+  mbox_send(1, 3, L2I smp_demo_clock);
+  mbox_send(2, 3, L2I smp_demo_sd);
+  mbox_send(3, 3, L2I smp_demo_pmap);
 
   pm_alloc(1 * L2I & _stack_size);
   vm_alloc(1 * L2I & _stack_size);
@@ -65,9 +63,9 @@ void smp_bootstrap() {
   paddr_t s2 = pm_alloc(L2I & _stack_size);
   paddr_t s3 = pm_alloc(L2I & _stack_size);
 
-  mbox_send(cpu + 1, 1, s1);
-  mbox_send(cpu + 2, 1, s2);
-  mbox_send(cpu + 3, 1, s3);
+  mbox_send(1, 1, s1);
+  mbox_send(2, 1, s2);
+  mbox_send(3, 1, s3);
 
   do {
     __asm__ volatile("wfe");


### PR DESCRIPTION
Rewrite main part of early boot process from asm to C code (putted in kernel/rpi.c).

In next steps I want to move more rest of the code to C (mostly cpu_mailbox_wait).

In this PR mmu and translation table are fully initialized in C code.